### PR TITLE
Issue #33: Compilation error on Kiosk Mode due to VST3_ManifestHelper

### DIFF
--- a/sinT.jucer
+++ b/sinT.jucer
@@ -5,7 +5,7 @@
               pluginCharacteristicsValue="pluginIsSynth,pluginWantsMidiIn"
               cppLanguageStandard="17" pluginManufacturer="AlbertoNR" companyName="AlbertoNR"
               pluginManufacturerCode="AlNR" pluginCode="Alnr" companyWebsite="https://github.com/AlbertoNR98/sinT"
-              version="1.1">
+              version="1.1.1">
   <MAINGROUP id="YdDlVH" name="sinT">
     <GROUP id="{AEAE61ED-FAE3-177E-149B-190C5214B3DB}" name="Source">
       <FILE id="DSBJlL" name="ParamsIDList.h" compile="0" resource="0" file="Source/ParamsIDList.h"/>
@@ -177,9 +177,9 @@
       <CONFIGURATIONS>
         <CONFIGURATION isDebug="1" name="Debug" targetName="sinT"/>
         <CONFIGURATION isDebug="0" name="Release" targetName="sinT" linkTimeOptimisation="1"/>
-        <CONFIGURATION isDebug="1" name="Debug_Kiosk" targetName="sinT" defines="JUCE_STANDALONE_FILTER_WINDOW_USE_KIOSK_MODE=1 JucePlugin_Build_VST3=0"/>
+        <CONFIGURATION isDebug="1" name="Debug_Kiosk" targetName="sinT" defines="JUCE_STANDALONE_FILTER_WINDOW_USE_KIOSK_MODE=1"/>
         <CONFIGURATION isDebug="0" name="Release_Kiosk" targetName="sinT" linkTimeOptimisation="1"
-                       defines="JUCE_STANDALONE_FILTER_WINDOW_USE_KIOSK_MODE=1 JucePlugin_Build_VST3=0"/>
+                       defines="JUCE_STANDALONE_FILTER_WINDOW_USE_KIOSK_MODE=1"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_audio_basics" path="../../../../JUCE/modules"/>
@@ -201,9 +201,9 @@
       <CONFIGURATIONS>
         <CONFIGURATION isDebug="1" name="Debug" targetName="sinT" userNotes="Standalone and VST3"/>
         <CONFIGURATION isDebug="0" name="Release" targetName="sinT" userNotes="Standalone and VST3"/>
-        <CONFIGURATION isDebug="1" name="Debug_Kiosk" targetName="sinT" defines="JUCE_STANDALONE_FILTER_WINDOW_USE_KIOSK_MODE=1 JucePlugin_Build_VST3=0"
+        <CONFIGURATION isDebug="1" name="Debug_Kiosk" targetName="sinT" defines="JUCE_STANDALONE_FILTER_WINDOW_USE_KIOSK_MODE=1"
                        userNotes="Standalone kiosk - Disable VST3 output before"/>
-        <CONFIGURATION isDebug="0" name="Release_Kiosk" targetName="sinT" defines="JUCE_STANDALONE_FILTER_WINDOW_USE_KIOSK_MODE=1 JucePlugin_Build_VST3=0"
+        <CONFIGURATION isDebug="0" name="Release_Kiosk" targetName="sinT" defines="JUCE_STANDALONE_FILTER_WINDOW_USE_KIOSK_MODE=1"
                        userNotes="Standalone kiosk - Disable VST3 output before"/>
       </CONFIGURATIONS>
       <MODULEPATHS>


### PR DESCRIPTION
- Delete the flag that prevents the compilation of the VST3 format plugin
- VST3 plugins created under kiosk mode configurations WILL BE INVALID AND MUST BE DELETED MANUALLY