### PR TITLE
sinT 1.1.1

### DIFF
--- a/sinT.jucer
+++ b/sinT.jucer
@@ -5,7 +5,7 @@
               pluginCharacteristicsValue="pluginIsSynth,pluginWantsMidiIn"
               cppLanguageStandard="17" pluginManufacturer="AlbertoNR" companyName="AlbertoNR"
               pluginManufacturerCode="AlNR" pluginCode="Alnr" companyWebsite="https://github.com/AlbertoNR98/sinT"
-              version="1.1.1dev">
+              version="1.1.1">
   <MAINGROUP id="YdDlVH" name="sinT">
     <GROUP id="{AEAE61ED-FAE3-177E-149B-190C5214B3DB}" name="Source">
       <FILE id="DSBJlL" name="ParamsIDList.h" compile="0" resource="0" file="Source/ParamsIDList.h"/>


### PR DESCRIPTION
- Updated JUCE version (7.0.5 to 7.0.12).
- Fix some JUCE bugs related to VST3 plugin export and kiosk mode Linux compilation.